### PR TITLE
fix for server crashing with GET /risk/Risks?=11

### DIFF
--- a/srv/risk-service.js
+++ b/srv/risk-service.js
@@ -40,9 +40,9 @@ module.exports = cds.service.impl(async function() {
 
     // Risks?$expand=supplier
     this.on("READ", 'Risks', async (req, next) => {
-        const expandIndex = req.query.SELECT.columns.findIndex(
+        const expandIndex = req.query.SELECT.columns?.findIndex(
             ({ expand, ref }) => expand && ref[0] === "supplier"
-        );
+        ) ?? -1;
         if (expandIndex < 0) return next();
 
         // Remove expand from query


### PR DESCRIPTION
The first query in ```test.http``` ```GET /risk/Risks?=11``` crashes the server as  there are no columns in the request.
This change checks for this condition so that the server does not crash.