### PR TITLE
Fix for server crashing on GET /risk/Risks?$top=11

### DIFF
--- a/srv/risk-service.js
+++ b/srv/risk-service.js
@@ -40,9 +40,9 @@ module.exports = cds.service.impl(async function() {
 
     // Risks?$expand=supplier
     this.on("READ", 'Risks', async (req, next) => {
-        const expandIndex = req.query.SELECT.columns.findIndex(
+        const expandIndex = req.query.SELECT.columns?.findIndex(
             ({ expand, ref }) => expand && ref[0] === "supplier"
-        );
+        ) ?? -1;
         if (expandIndex < 0) return next();
 
         // Remove expand from query


### PR DESCRIPTION
The server crashes on GET /risk/Risks?$top=11.
This the first query in ```test.http```
The crash was because empty select was not handled in the implementation. 
This changes checks for empty $select.